### PR TITLE
.github/workflows: Update Artifact Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Uploads artifact
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: exe
           path: build/server.exe


### PR DESCRIPTION
Currently, we're running the GitHub Artifact Actions v3 or lower, which will be deprecated by
2025-01-31, as noticed in [this blog post](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

This updates the actions to version 4 in order to avoid workflow failure.